### PR TITLE
Pressing "back" button twice sends the display to Startup mask.

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -168,7 +168,7 @@ if __name__ == "__main__":
 
     def klippy_state_changed(state : KlippyState, state_message : str):
         if state == KlippyState.READY:
-            display.switch_to_mask(30)
+            display.switch_to_mask(30, False)
             display.switch_to_mask(0)
 
         else:# state == KlippyState.ERROR or state == KlippyState.SHUTDOWN:


### PR DESCRIPTION
When "Startup Mask" is activated automatically, the Mask is not added to switch back history.

Fixes #33