### PR TITLE
add documentation for disabling serial console

### DIFF
--- a/doc/usage/installation/display_connection.rst
+++ b/doc/usage/installation/display_connection.rst
@@ -86,3 +86,9 @@ Using Pi Serial interface
 
     * set *"ip": "10.0.1.69"*
 
+#) Disable Serial Console   
+
+.. code-block:: shell
+
+    git clone https://github.com/seho85/klipper-dgus.git
+


### PR DESCRIPTION
The "/dev/ttyAMA0" device has wrong permissions, so that the klipper_dgus service can't access it.

This command disables it and thus prevents it from changing the permissions.